### PR TITLE
allow the cli tool to be used with tls

### DIFF
--- a/bin/bouncy.js
+++ b/bin/bouncy.js
@@ -1,17 +1,25 @@
 #!/usr/bin/env node
 var configFile = process.argv[2];
 var port = parseInt(process.argv[3], 10);
+var key = process.argv[4];
+var cert = process.argv[5];
 
 if (!configFile || !port) {
-    console.error('Usage: bouncy [routes.json] [port]');
+    console.error('Usage: bouncy [routes.json] [port] [keyfile] [certfile]');
     process.exit(1);
 }
 
 var fs = require('fs');
 var config = JSON.parse(fs.readFileSync(configFile));
 
+var opts = {};
+if (key && cert) {
+    opts.key = fs.readFileSync(key);
+    opts.cert = fs.readFileSync(cert);
+}
+
 var bouncy = require('bouncy');
-bouncy(function (req, bounce) {
+bouncy(opts, function (req, bounce) {
     var host = (req.headers.host || '').replace(/:\d+$/, '');
     var route = config[host] || config[''];
     


### PR DESCRIPTION
This was a simple change, so maybe there’s a reason you haven’t implemented it already. In any case:

Previously, TLS could only be used by writing code and passing in the correct `opts` to the `bouncy()` funciton.

If you weren’t using TLS, you could use the simpler command-line utility.

This adds two optional arguments to the command-line utility to support TLS usage, without breaking existing non-TLS code.
